### PR TITLE
fix(vscode): only replace node link if it exists

### DIFF
--- a/wsl.nix
+++ b/wsl.nix
@@ -86,8 +86,10 @@
   #   };
   #   services.vscode-remote-workaround.script = ''
   #     for i in ~/.vscode-server/bin/*; do
-  #       echo "Fixing vscode-server in $i..."
-  #       ln -sf ${pkgs.nodejs_18}/bin/node $i/node
+  #       if [ -e $i/node ]; then
+  #         echo "Fixing vscode-server in $i..."
+  #         ln -sf ${pkgs.nodejs_18}/bin/node $i/node
+  #       fi
   #     done
   #   '';
   # };


### PR DESCRIPTION
for whatever reason, my vscode remote server bin directory looks like this:
```console
$ ll ~/.vscode-server/bin/
total 8
-rw-r--r-- 1 backwardspy users    1 Apr 14 13:49 compatibilty-check
drwxr-xr-x 6 backwardspy users 4096 Apr 14 14:35 e170252f762678dec6ca2cc69aba1570769a5d39
```

that "compatibilty-check" (sic) file caused the remote workaround script to fail as it is not a directory containing a `node` executable:

```
Started vscode-remote-workaround.service.
Fixing vscode-server in /home/backwardspy/.vscode-server/bin/compatibilty-check...
ln: failed to access '/home/backwardspy/.vscode-server/bin/compatibilty-check/node': Not a directory
vscode-remote-workaround.service: Main process exited, code=exited, status=1/FAILURE
vscode-remote-workaround.service: Failed with result 'exit-code'.
```

let me know if you'd prefer a different fix to the one i chose.